### PR TITLE
chore: Upgrade Python and dependencies

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.14"
     - name: Install dependencies
       env:
         REQUIREMENTS_FILE: lint
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.14"
     - name: Install dependencies
       env:
         REQUIREMENTS_FILE: typecheck
@@ -73,7 +73,7 @@ jobs:
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.14"
     - name: Install dependencies
       env:
         REQUIREMENTS_FILE: test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.14-alpine AS build
-RUN python3.14 -m pip install --upgrade pip setuptools wheel
+RUN python3.14 -m pip install --upgrade pip "setuptools>=83.0.0" "wheel>=0.47.0"
 
 WORKDIR /app
 COPY setup.cfg .

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,31 +20,31 @@ project_urls =
 package_dir =
     = src
 packages = find_namespace:
-python_requires = >=3.12
+python_requires = >=3.14
 setup_requires =
-    setuptools>=60.2.0
-    wheel>=0.37.1
+    setuptools>=83.0.0
+    wheel>=0.47.0
 install_requires =
-    SQLAlchemy>=2.0.29
-    aiohttp>=3.9.3
-    psycopg2-binary>=2.9.9
-    beautifulsoup4>=4.13.0b2
-    requests==2.28.1
+    SQLAlchemy>=2.0.51
+    aiohttp>=3.14.1
+    psycopg2-binary>=2.9.12
+    beautifulsoup4>=4.15.0
+    requests>=2.34.2
 zip_safe = false
 include_package_data = true
 
 [options.extras_require]
 dev =
 lint =
-    flake8>=7.0.0
+    flake8>=7.3.0
 typecheck =
-    mypy>=1.9.0
-    sqlalchemy[mypy]>=2.0.29
-    types-requests>=2.30.0
+    mypy>=2.3.0
+    sqlalchemy[mypy]>=2.0.51
+    types-requests>=2.33.0.20260712
 test =
-    pytest<8.0.0
-    pytest-asyncio>=0.20.2
-    pytest-cov>=3.0.0
+    pytest>=9.1.1
+    pytest-asyncio>=1.4.0
+    pytest-cov>=7.1.0
 [mypy]
 plugins = sqlalchemy.ext.mypy.plugin
 ignore_missing_imports = true

--- a/src/scripts/menu.py
+++ b/src/scripts/menu.py
@@ -1,6 +1,6 @@
 import datetime
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 from requests import Response
 from sqlalchemy import select, delete, insert, and_
 from sqlalchemy.orm import Session
@@ -48,21 +48,27 @@ async def get_menu_data(
             if container:
                 items = container.find_all("div", class_="hyu-list-body-item-col menu-thumbnail")
                 for menu_item in items:
-                    detail_p = menu_item.find_next("div", class_="menu-detail").find_next("p")
-                    if not detail_p:
+                    if not isinstance(menu_item, Tag):
+                        continue
+                    detail_container = menu_item.find_next("div", class_="menu-detail")
+                    if not isinstance(detail_container, Tag):
+                        continue
+                    detail_p = detail_container.find_next("p")
+                    if not isinstance(detail_p, Tag):
                         continue
                     menu_text = detail_p.get_text(strip=True)
-                    price_h3 = menu_item.find_next("div", class_="menu-price").find_next("h3")
-                    price_text = price_h3.get_text(strip=True) if price_h3 else ""
-                    menu_item = HashableDict(dict(
+                    price_container = menu_item.find_next("div", class_="menu-price")
+                    price_h3 = price_container.find_next("h3") if isinstance(price_container, Tag) else None
+                    price_text = price_h3.get_text(strip=True) if isinstance(price_h3, Tag) else ""
+                    menu_entry = HashableDict(dict(
                         restaurant_id=restaurant_id,
                         feed_date=day.strftime("%Y-%m-%d"),
                         time_type=title,
                         menu_food=str(menu_text).strip(),
                         menu_price=price_text.replace("원", "").strip()
                     ))
-                    if menu_item not in menu_items:
-                        menu_items.append(menu_item)
+                    if menu_entry not in menu_items:
+                        menu_items.append(menu_entry)
     if menu_items:
         # Remove duplicate menu items
         menu_set = [x.to_dict() for x in list(set(menu_items))]


### PR DESCRIPTION
## Summary

- Raise the supported runtime from Python 3.13 to Python 3.14.
- Upgrade SQLAlchemy, aiohttp, psycopg2, Beautiful Soup, Requests, and packaging dependencies.
- Upgrade pytest, pytest-asyncio, pytest-cov, mypy, flake8, and typing stubs.
- Update cafeteria menu parsing annotations for the current Beautiful Soup type model.
- Align the Docker image and GitHub Actions environment with Python 3.14.

## Test plan

- [x] Install runtime and development dependencies on Python 3.14
- [x] Run flake8 and mypy
- [x] Build the wheel without resolving dependencies
- [ ] GitHub Actions lint, type-check, and database-backed tests
