### PR TITLE
fix: Use cleaned Buildx workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   publish:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
-    uses: hyuabot-developers/hyuabot-infrastructure/.github/workflows/publish-immutable-image.yml@8f1f01759d39340962b33d8cbba4835980715a4c
+    uses: hyuabot-developers/hyuabot-infrastructure/.github/workflows/publish-immutable-image.yml@0b1e1c48a2766faaa5c7571f36b79d2fc9bb9484
     with:
       image-repository: localhost:5000/hyuabot-cafeteria-updater
       workload-kind: cronjob


### PR DESCRIPTION
## Summary

- Pin the reusable image workflow to the revision that removes BuildKit builders and their state after each build.

## Validation

- Ran `git diff --check`.
- The reusable workflow is verified on the online `Jeongin-MBP` container-build runner.